### PR TITLE
Add simple Model Hosting notebooks

### DIFF
--- a/examples/model_hosting/notebook/advanced_temperature_converter/AdvancedTemperatureConverter.ipynb
+++ b/examples/model_hosting/notebook/advanced_temperature_converter/AdvancedTemperatureConverter.ipynb
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we start each the cell with `# !model`. This means this code will be included in our model. The next cells below will only be for local exection, and are not supposed to be executed in Model Hosting. And thus do not start with `# !model`. For our model to work with Model Hosting we have to define a `predict()` function. It's first parameter must be `instance` - the entity on which to perform prediction on. After that we may define our own parameters. We can of course also define other functions (and classes, etc) to help us do the prediction as we have done above.\n",
+    "Notice that we start each the cell with `# !model`. This means this code will be included in our model. The next cells below will only be for local execution, and are not supposed to be executed in Model Hosting. And thus do not start with `# !model`. For our model to work with Model Hosting we have to define a `predict()` function. It's first parameter must be `instance` - the entity on which to perform prediction on. After that we may define our own parameters. We can of course also define other functions (and classes, etc) to help us do the prediction as we have done above.\n",
     "\n",
     "Okey, now we have defined our model. Let's try it out locally before we deploy it to Model Hosting."
    ]

--- a/examples/model_hosting/notebook/advanced_temperature_converter/AdvancedTemperatureConverter.ipynb
+++ b/examples/model_hosting/notebook/advanced_temperature_converter/AdvancedTemperatureConverter.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction\n",
+    "\n",
+    "In this tutorial we will deploy a more advanced version of the temperature converter we created in the \"Simple Temperature Converter tutorial\". It will support arbitrary conversion between Celsius, Fahrenheit and Kelvin of arrays of temperature values. Of course, having a model for such a simple task would usually be overkill, but it's a nice example. Deploying a notebook is great for simple models and trying out things. For more complex models with a lot of code and many dependencies you should consider creating a proper source package.\n",
+    "\n",
+    "**Requirements**:\n",
+    "- You need to have the `cognite-model-hosting-notebook` package installed\n",
+    "- The environment variable `COGNITE_API_KEY` should be set"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Defining our model\n",
+    "\n",
+    "First off we need to define our dependencies. This is simply achieved by creating a code cell that start with `# !requirements`. Our model will use `numpy` for calculations on arrays of numbers, so we'll be sure to add that. It's always good practice to be specific of the version of the package to avoid breaking changes in the future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !requirements\n",
+    "# numpy==1.16.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we need to specify the code the prediction routine of our model will run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !model\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !model\n",
+    "def celsius_to_kelvin(t):\n",
+    "    return t + 273.15\n",
+    "\n",
+    "def fahrenheit_to_kelvin(t):\n",
+    "    return (t + 459.67) * (5/9)\n",
+    "\n",
+    "def kelvin_to_celsius(t):\n",
+    "    return t - 273.15\n",
+    "\n",
+    "def kelvin_to_fahrenheit(t):\n",
+    "    return t * (9/5) - 459.67\n",
+    "\n",
+    "def to_kelvin(t, from_scale):\n",
+    "    if from_scale == \"K\":\n",
+    "        return t\n",
+    "    elif from_scale == \"C\":\n",
+    "        return celsius_to_kelvin(t)\n",
+    "    elif from_scale == \"F\":\n",
+    "        return fahrenheit_to_kelvin(t)\n",
+    "    else:\n",
+    "        raise AssertionError(\"Don't recognize temperature scale `{}`\".format(from_scale))\n",
+    "\n",
+    "def from_kelvin(t, to_scale):\n",
+    "    if to_scale == \"K\":\n",
+    "        return t\n",
+    "    elif to_scale == \"C\":\n",
+    "        return kelvin_to_celsius(t)\n",
+    "    elif to_scale == \"F\":\n",
+    "        return kelvin_to_fahrenheit(t)\n",
+    "    else:\n",
+    "        raise AssertionError(\"Don't recognize temperature scale `{}`\".format(to_scale))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !model\n",
+    "def predict(instance, from_scale, to_scale):\n",
+    "    t = np.array(instance)\n",
+    "    \n",
+    "    t = to_kelvin(t, from_scale)\n",
+    "    t = from_kelvin(t, to_scale)\n",
+    "    \n",
+    "    return t.tolist() # The returned value must be JSON serializable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that we start each the cell with `# !model`. This means this code will be included in our model. The next cells below will only be for local exection, and are not supposed to be executed in Model Hosting. And thus do not start with `# !model`. For our model to work with Model Hosting we have to define a `predict()` function. It's first parameter must be `instance` - the entity on which to perform prediction on. After that we may define our own parameters. We can of course also define other functions (and classes, etc) to help us do the prediction as we have done above.\n",
+    "\n",
+    "Okey, now we have defined our model. Let's try it out locally before we deploy it to Model Hosting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[21.1111111111112, 26.666666666666742, 32.222222222222285]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predict([70, 80, 90], from_scale=\"F\", to_scale=\"C\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[31.999999999999943, 13.999999999999943, 49.99999999999994]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predict([0, -10, 10], from_scale=\"C\", to_scale=\"F\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0.0, 100.0, 26.850000000000023]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predict([273.15, 373.15, 300], from_scale=\"K\", to_scale=\"C\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Seems to be working nicely!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploying our model\n",
+    "\n",
+    "It's time to deploy our model. Let's first import what we need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cognite.client import CogniteClient\n",
+    "from cognite.model_hosting.notebook import deploy_model_version\n",
+    "\n",
+    "model_hosting = CogniteClient().experimental.model_hosting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To deploy a model version we first need a model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = model_hosting.models.create_model(\"temperature-converter\").id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then we deploy this notebook as a model version. It's important you **save the notebook** before doing this since the notebook file will be read to find your model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_version_id = deploy_model_version(\n",
+    "    name=\"temperature-converter-v1\",\n",
+    "    model_id=model_id,\n",
+    "    runtime_version=\"0.1\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we just have to wait for the deployment to finish. This usually takes a few minutes. Notice that the next step won't work before the status of the model version is 'READY'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'READY'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_hosting.models.get_model_version(model_id, model_version_id).status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing the model\n",
+    "\n",
+    "Now that's it deployed we can test it out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[31.999999999999943, 13.999999999999943, 49.99999999999994],\n",
+       " [-58.00000000000006, 211.99999999999994]]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_hosting.models.online_predict(\n",
+    "    model_id,\n",
+    "    model_version_id,\n",
+    "    instances=[[0, -10, 10], [-50, 100]],\n",
+    "    args={\"from_scale\": \"C\", \"to_scale\": \"F\"}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's important to note that these predictions were performed in Cognite Model Hosting in the cloud, not on your computer. Anyone with internet (and appropriate access rights) can now access this model!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When you're done - remember to clean up after yourself:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_package_id = model_hosting.models.get_model_version(model_id, model_version_id).source_package_id\n",
+    "model_hosting.models.delete_model(model_id)\n",
+    "model_hosting.source_packages.delete_source_package(source_package_id)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/model_hosting/notebook/simple_temperature_converter/SimpleTemperatureConverter.ipynb
+++ b/examples/model_hosting/notebook/simple_temperature_converter/SimpleTemperatureConverter.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction\n",
+    "\n",
+    "In this tutorial we will deploy a simplest possible model to Cognite Model Hosting from a notebook. A model that convert from fahrenheit to celcius. Of course, having a model for such a simple task would usually be overkill, but it's a nice example. Deploying a notebook is great for simple models and trying out things. For more complex models with a lot of code and many dependencies you should consider creating a proper source package.\n",
+    "\n",
+    "**Requirements**:\n",
+    "- You need to have the `cognite-model-hosting-notebook` package installed\n",
+    "- The environment variable `COGNITE_API_KEY` should be set"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Defining our model\n",
+    "\n",
+    "First off we need to define our dependencies. This is simply achieved by creating a code cell that start with `# !requirements`. Since we have no dependencies we'll leave the rest of the cell empty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !requirements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we need to specify the code the prediction routine of our model will run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !model\n",
+    "def predict(instance):\n",
+    "    return (instance - 32) * (5/9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that we start the cell with `# !model`. This way we say that this code should be included in our model. The next cells below will only be for local exection, and are not supposed to be ran in Model Hosting. And thus do not start with `# !model`.\n",
+    "\n",
+    "Okey, now we have defined our model. Let's try it out locally before we deploy it to Model Hosting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "21.11111111111111"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predict(70)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Seems to be working nicely!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploying our model\n",
+    "\n",
+    "It's time to deploy our model. Let's first import what we need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cognite.client import CogniteClient\n",
+    "from cognite.model_hosting.notebook import deploy_model_version\n",
+    "\n",
+    "model_hosting = CogniteClient().experimental.model_hosting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To deploy a model version we first need a model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = model_hosting.models.create_model(\"fahrenheit-to-celsius\").id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then we deploy this notebook as a model version. It's important you **save the notebook** before doing this since the notebook file will be read to find your model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_version_id = deploy_model_version(\n",
+    "    name=\"fahrenheit-celsius-v1\",\n",
+    "    model_id=model_id,\n",
+    "    runtime_version=\"0.1\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we just have to wait for the deployment to finish. This usually takes a few minutes. Notice that the next step won't work before the status of the model version is 'READY'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'READY'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_hosting.models.get_model_version(model_id, model_version_id).status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing the model\n",
+    "\n",
+    "Now that's it deployed we can test it out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[21.11111111111111, 26.666666666666668, 32.22222222222222]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_hosting.models.online_predict(model_id, model_version_id, instances=[70, 80, 90])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's important to note that these predictions were performed in Cognite Model Hosting in the cloud, not on your computer. Anyone with internet (and appropriate access rights) can now access this model!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When you're done - remember to clean up after yourself:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_package_id = model_hosting.models.get_model_version(model_id, model_version_id).source_package_id\n",
+    "model_hosting.models.delete_model(model_id)\n",
+    "model_hosting.source_packages.delete_source_package(source_package_id)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/model_hosting/notebook/simple_temperature_converter/SimpleTemperatureConverter.ipynb
+++ b/examples/model_hosting/notebook/simple_temperature_converter/SimpleTemperatureConverter.ipynb
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we start the cell with `# !model`. This way we say that this code should be included in our model. The next cells below will only be for local exection, and are not supposed to be ran in Model Hosting. And thus do not start with `# !model`.\n",
+    "Notice that we start the cell with `# !model`. This way we say that this code should be included in our model. The next cells below will only be for local execution, and are not supposed to be ran in Model Hosting. And thus do not start with `# !model`.\n",
     "\n",
     "Okey, now we have defined our model. Let's try it out locally before we deploy it to Model Hosting."
    ]


### PR DESCRIPTION
Since it's hassle to review notebooks I figured it would be nice to do this in two PRs. This first one includes two simple notebooks showing two minimalistic models and how to deploy them from a notebook. The plan for the next PR would be:

- A notebook showing training - both locally (pretrained) and in Model Hosting.
- A notebook showing a more complex model (no training) which is scheduled.
- Update the Model Hosting README to mention all new four notebooks.
- Add cognite-model-hosting-notebook to Pipfile and requirements.txt (must be published first - working on that)